### PR TITLE
Implementation of EventEmitter inside the dequeue

### DIFF
--- a/JavaScript/3-dequeue.js
+++ b/JavaScript/3-dequeue.js
@@ -1,9 +1,11 @@
 'use strict';
+const EventEmitter = require('events');
 
 class Dequeue {
   constructor() {
     this.first = null;
     this.last = null;
+    this._emitter = new EventEmitter();
   }
   push(item) {
     const last = this.last;
@@ -15,6 +17,7 @@ class Dequeue {
       this.first = element;
       this.last = element;
     }
+    this._emitter.emit('push', element.item, this);
   }
   pop() {
     const element = this.last;
@@ -25,6 +28,7 @@ class Dequeue {
     } else {
       this.last = element.prev;
     }
+    this._emitter.emit('pop', element.item, this);
     return element.item;
   }
   unshift(item) {
@@ -37,6 +41,7 @@ class Dequeue {
       this.first = element;
       this.last = element;
     }
+    this._emitter.emit('unshift', element.item, this);
   }
   shift() {
     const element = this.first;
@@ -47,7 +52,29 @@ class Dequeue {
     } else {
       this.first = element.next;
     }
+    this._emitter.emit('shift', element.item, this);
     return element.item;
+  }
+  on(...args) {
+    return this._emitter.on(...args);
+  }
+  once(...args) {
+    return this._emitter.once(...args);
+  }
+  remove(...args) {
+    return this._emitter.removeListener(...args);
+  }
+  clear(...args) {
+    return this._emitter.removeAllListeners(...args);
+  }
+  listeners(...args) {
+    return this._emitter.listeners(...args);
+  }
+  count(...args) {
+    return this._emitter.listenerCount(...args);
+  }
+  names() {
+    return this._emitter.eventNames();
   }
 }
 


### PR DESCRIPTION
It was stated as a task for this repository, so I've decided to try. My implementation has all methods that production EventEmitter from HPW/EventEmitter has but taken from EE of built-in library. .emit() is "protected" by holding in this._emitter which is the only way to say "don't touch" as I know. And actually I can't see better sollution because event holding it in wrapper has no sense(I think) cause this wrapper can't be sure from where the call comes. Please review my code and/or tell me if you know better way to protect the .emit() function or if I've implemented wrong contract for it.