### PR TITLE
Added clearing of links to a deleted item

### DIFF
--- a/JavaScript/3-dequeue.js
+++ b/JavaScript/3-dequeue.js
@@ -26,6 +26,7 @@ class Dequeue {
       this.last = null;
     } else {
       this.last = element.prev;
+      this.last.next = null;
     }
     return element.item;
   }
@@ -50,6 +51,7 @@ class Dequeue {
       this.last = null;
     } else {
       this.first = element.next;
+      this.first.prev = null;
     }
     return element.item;
   }


### PR DESCRIPTION
Добавил очистку от ссылок на удаленный (с виду) элемент при помощи методов: pop(), shift(). Элемент, который мы удаляем остается в памяти, т. к. на него ссылается предыдущий элемент или следующий, в зависимости от выбранного направления.
Например, элемент, который мы удалили при помощи метода pop() остается висеть в памяти, ибо на него ссылается предыдущий элемент - новый this.last.